### PR TITLE
Remove html_static_path from conf.py

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -31,4 +31,4 @@ exclude_patterns = []
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = "sphinx_book_theme"
-html_static_path = ["_static"]
+# html_static_path = ["_static"]


### PR DESCRIPTION
This PR removes the html_static_path configuration from the conf.py file.