### PR TITLE
Update Travis CI configuration for deploying pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ branches:
   only:
     - main
 deploy:
-  provider: pages
-  skip_cleanup: true
-  github_token: $GITHUB_TOKEN
+  provider: pages:git
+  token: $GITHUB_TOKEN
   keep_history: true
   on:
     branch: main
   local_dir: doc/build/html
+  edge: true


### PR DESCRIPTION
This pull request updates the Travis CI configuration for deploying pages. The provider has been changed to "pages:git" and the "skip_cleanup" option has been removed. Additionally, the "github_token" option has been replaced with "token" and the "edge" option has been added. This ensures that the pages are deployed correctly and keeps the commit history intact.