### PR TITLE
Fixing GPU support.

### DIFF
--- a/examples/example.py
+++ b/examples/example.py
@@ -55,7 +55,7 @@ def objective_function(signature):
     latent_dim = len(signature) * 2
     model = GeometricAutoencoder(signature, latent_dim=latent_dim)
     train_losses, test_loss = train_and_evaluate(
-        model, train_loader, test_loader, epochs=epochs
+        model, train_loader, test_loader, epochs=epochs, device=torch.device("cuda")
     )
     return train_losses, test_loss
 

--- a/nlgm/manifolds.py
+++ b/nlgm/manifolds.py
@@ -95,17 +95,17 @@ class SphericalManifold(BasicManifold):
         Returns:
             torch.Tensor: The result of applying the exponential map to the tangent vector.
         """
+        device = torch.get_device(tangent_vector)
+
         # Compute the L2 norm of the tangent vector
         # $\sqrt{K_S}|x|$
-        norm_v = torch.sqrt(torch.abs(self.curvature)) * torch.norm(
+        norm_v = torch.sqrt(torch.abs(self.curvature.to(device))) * torch.norm(
             tangent_vector, dim=-1, keepdim=True
         )
 
         # Compute the unit direction vector by dividing the tangent vector by its norm
         # $\frac{x}{\sqrt{K_S}\|x\|}$
         direction = tangent_vector / norm_v.clamp_min(1e-6)
-
-        device = torch.get_device(direction)
 
         # Apply the exponential map formula for spherical manifold
         # $\cos(\sqrt{K_S}\|x\|)x_p + \sin(\sqrt{K_S}\|x\|)\frac{x}{\sqrt{K_S}\|x\|}$
@@ -125,11 +125,11 @@ class SphericalManifold(BasicManifold):
         Returns:
             torch.Tensor: The geodesic distance between the two points.
         """
+        device = torch.get_device(point_x)
+
         # Compute the inner product between point_x and point_y
         # $(x,y)_2 := \langle\mathbf{x}, \mathbf{y}\rangle$
         inner_product = (point_x * point_y).sum(dim=-1)
-
-        device = torch.get_device(inner_product)
 
         # Compute the geodesic distance using the arc-cosine of the inner product
         # $\arccos(K_S * (x,y)_2) / \sqrt{|K|}$
@@ -149,17 +149,17 @@ class HyperbolicManifold(BasicManifold):
         Returns:
             torch.Tensor: The result of applying the exponential map to the tangent vector.
         """
+        device = torch.get_device(tangent_vector)
+
         # Compute the L2 norm of the tangent vector
         # $\sqrt{-K_H}|x|$
-        norm_v = torch.sqrt(torch.abs(self.curvature)) * torch.norm(
+        norm_v = torch.sqrt(torch.abs(self.curvature.to(device))) * torch.norm(
             tangent_vector, dim=-1, keepdim=True
         )
 
         # Compute the unit direction vector by dividing the tangent vector by its norm
         # $\frac{x}{\sqrt{-K_H}\|x\|}$
         direction = tangent_vector / norm_v.clamp_min(1e-6)
-
-        device = torch.get_device(direction)
 
         # Apply the exponential map formula for hyperbolic manifold
         # $\cosh(\sqrt{-K_H}\|x\|)x_p + \sinh(\sqrt{-K_H}\|x\|)\frac{x}{\sqrt{-K_H}\|x\|}$
@@ -179,13 +179,13 @@ class HyperbolicManifold(BasicManifold):
         Returns:
             torch.Tensor: The geodesic distance between the two points.
         """
+        device = torch.get_device(point_x)
+
         # Compute the Lorentz inner product between point_x and point_y
         # $-(x_p,y_1)_L$, where $(x,y)_L$ denotes the Lorentz inner product
         inner_product = -(point_x[..., 0] * point_y[..., 0]) + (
             point_x[..., 1:] * point_y[..., 1:]
         ).sum(dim=-1)
-
-        device = torch.get_device(inner_product)
 
         # Compute the geodesic distance using the arc-hyperbolic cosine of the inner product
         # $\frac{1}{\sqrt{-K_H}} \mathrm{arccosh}(K_H*(x,y)_L)$

--- a/nlgm/train.py
+++ b/nlgm/train.py
@@ -1,6 +1,6 @@
 import torch
 from torch import nn
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 
 def train_and_evaluate(

--- a/nlgm/train.py
+++ b/nlgm/train.py
@@ -30,6 +30,8 @@ def train_and_evaluate(
 
     train_losses = []
 
+    model.to(device)
+
     it = tqdm(range(epochs), desc="Epochs") if progress_bar else range(epochs)
     for epoch in it:
         model.train()


### PR DESCRIPTION
Currently, the member parameters of the BasicManifold and children classes are not being transferred properly to the GPU when the model is moved to the GPU. The objective of this PR is to fix this and make it ergonomic to use.

Instead of inheriting from torch.nn.Module, it seems that it makes sense to just assume that the output should be on the same device as the input tensors when using the manifold classes to compute projections.