### PR TITLE
Hotfix: Fix dependencies for project when installing from PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,8 @@ python:
 dist: jammy
 install:
   - pip install uv
-  - uv pip install -r requirements.txt
   - travis_retry uv pip install -U -r doc/requirements.txt
-  - travis_retry uv pip install -e .
+  - travis_retry uv pip install -e .[dev, vis]
 after_success:
   - make -C doc html
   - touch /home/travis/build/ae-bii/nlgm/doc/build/html/.nojekyll

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dist: jammy
 install:
   - pip install uv
   - travis_retry uv pip install -U -r doc/requirements.txt
-  - travis_retry uv pip install -e .[dev, vis]
+  - travis_retry uv pip install -e ".[dev,vis]"
 after_success:
   - make -C doc html
   - touch /home/travis/build/ae-bii/nlgm/doc/build/html/.nojekyll

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ pip install nlgm
 You can install optional packages for development or visualization using:
 
 ```bash
-pip install .[dev, vis]     # install from pyproject.toml
-pip install nlgm[dev, vis]  # install from pypi
+pip install .[dev,vis]     # install from pyproject.toml
+pip install nlgm[dev,vis]  # install from pypi
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ This package is compatible with libraries like NumPy and PyTorch. For documentat
 To install `nlgm`, you can use pip:
 
 ```bash
-pip install nlgm # from pypi
+pip install nlgm
 ```
 
 You can install optional packages for development or visualization using:
 
 ```bash
-pip install .[dev, vis]    # install from pyproject.toml
-pip install nlgm[dev, vis] # install from pypi
+pip install .[dev, vis]     # install from pyproject.toml
+pip install nlgm[dev, vis]  # install from pypi
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -22,7 +22,14 @@ This package is compatible with libraries like NumPy and PyTorch. For documentat
 To install `nlgm`, you can use pip:
 
 ```bash
-pip install nlgm
+pip install nlgm # from pypi
+```
+
+You can install optional packages for development or visualization using:
+
+```bash
+pip install .[dev, vis]    # install from pyproject.toml
+pip install nlgm[dev, vis] # install from pypi
 ```
 
 ## Usage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
 dependencies = [
     "torch",
     "numpy",
-    "requests",
     "tqdm",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,17 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
+dependencies = [
+    "torch",
+    "numpy",
+    "requests",
+    "tqdm",
+]
+
+[project.optional-dependencies]
+vis = ["matplotlib", "networkx"]
+dev = ["pytest"]
+
 
 [project.urls]
 Homepage = "https://github.com/ae-bii/nlgm"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-torch
-numpy
-setuptools
-requests
-tqdm
-matplotlib
-networkx


### PR DESCRIPTION
Currently the dependencies are only being in the requirements.txt file and not the pyproject.toml. This means that when you install the package from PyPI, none of the dependencies are installed!