### PR TITLE
Hotfix: Fix dependencies for project when installing from PyPI (#34)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,8 @@ python:
 dist: jammy
 install:
   - pip install uv
-  - uv pip install -r requirements.txt
   - travis_retry uv pip install -U -r doc/requirements.txt
-  - travis_retry uv pip install -e .
+  - travis_retry uv pip install -e ".[dev,vis]"
 after_success:
   - make -C doc html
   - touch /home/travis/build/ae-bii/nlgm/doc/build/html/.nojekyll

--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ To install `nlgm`, you can use pip:
 pip install nlgm
 ```
 
+You can install optional packages for development or visualization using:
+
+```bash
+pip install .[dev,vis]     # install from pyproject.toml
+pip install nlgm[dev,vis]  # install from pypi
+```
+
 ## Usage
 
 After installing, you can import the package and use it by following the [example](https://github.com/ae-bii/nlgm/blob/main/examples/example.py).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,16 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
+dependencies = [
+    "torch",
+    "numpy",
+    "tqdm",
+]
+
+[project.optional-dependencies]
+vis = ["matplotlib", "networkx"]
+dev = ["pytest"]
+
 
 [project.urls]
 Homepage = "https://github.com/ae-bii/nlgm"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-torch
-numpy
-setuptools
-requests
-tqdm
-matplotlib
-networkx


### PR DESCRIPTION
* Moved dependencies to pyproject.toml and removed requirements.txt (for now) due to no pinned dep. versions.

* Updated README.md with minor spacing tweaks.

* Update .travis.yml for corrected CI with new deps.

* Update CI and readme to correct spacing issue when installing extras.

* Update pyproject.toml to remove requests dependency.