### PR TITLE
Hotfix: Update Python versions to 3.8 in GitHub workflows and project configuration

### DIFF
--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.8'
 
       - name: Upgrade pip
         run: |

--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.11" ]
+        python-version: [ "3.8" ]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.8"
 
       - name: Build release distributions
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
   { name="Kevin Qiu", email="kzq2000@columbia.edu" }
 ]
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.8"
 license = {file = "LICENSE"}
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 requires =
     tox>=4
-env_list = py{311}
+env_list = py{38}
 
 [testenv]
 description = run unit tests


### PR DESCRIPTION
This pull request updates the Python versions in the GitHub workflows and project configuration files to use Python 3.8 instead of 3.11. This ensures compatibility with the desired Python version and avoids any potential issues.